### PR TITLE
updated social event section

### DIFF
--- a/program.html
+++ b/program.html
@@ -310,7 +310,7 @@
   <h2>Mapbox Happy Hour</h2>
   <p>Mapbox is hosting a <a href="https://www.mapbox.com/blog/sotm-asia-happy-hour-2016/">Happy Hour</a>
     to celebrate the progress OpenStreetMap is making and to hang out with the
-    local community. Mapbox will be represented by a team of five in Quezon City
+    local community. Mapbox will be represented by a team of five in State of the Map Asia
     to talk about Mapbox, maps and their work in OpenStreetMap.
     Drop by for a drink and say hi!</p>
   <dl>


### PR DESCRIPTION
from "... by a team of five in Quezon City.." to "by a team of five in State of the Map Asia"
